### PR TITLE
Kpmp 6703 use links

### DIFF
--- a/src/components/SpatialViewer/ImageDatasetList.js
+++ b/src/components/SpatialViewer/ImageDatasetList.js
@@ -107,7 +107,16 @@ class ImageDatasetList extends Component {
                 sortable: true,
                 hideable: false,
                 defaultHidden: false,
-                getCellValue: row => <a href={`/spatial-viewer/view?image=${row['dlfileid']}`} target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</a>
+                getCellValue: row => {
+                    if(row['configtype'] !== 'external_link') {
+                        return <a href={`/spatial-viewer/view?image=${row['dlfileid']}`} target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</a>
+
+                    }else {
+                        return <button onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</button>
+                    }
+
+                }
+                // getCellValue: row => <a href={`/spatial-viewer/view?image=${row['dlfileid']}`} target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</a>
             },
             {
                 name: 'redcapid',

--- a/src/components/SpatialViewer/ImageDatasetList.js
+++ b/src/components/SpatialViewer/ImageDatasetList.js
@@ -107,7 +107,7 @@ class ImageDatasetList extends Component {
                 sortable: true,
                 hideable: false,
                 defaultHidden: false,
-                getCellValue: row => <button onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</button>
+                getCellValue: row => <a href='#' target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</a>
             },
             {
                 name: 'redcapid',

--- a/src/components/SpatialViewer/ImageDatasetList.js
+++ b/src/components/SpatialViewer/ImageDatasetList.js
@@ -114,9 +114,7 @@ class ImageDatasetList extends Component {
                     }else {
                         return <button onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</button>
                     }
-
                 }
-                // getCellValue: row => <a href={`/spatial-viewer/view?image=${row['dlfileid']}`} target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</a>
             },
             {
                 name: 'redcapid',

--- a/src/components/SpatialViewer/ImageDatasetList.js
+++ b/src/components/SpatialViewer/ImageDatasetList.js
@@ -107,7 +107,7 @@ class ImageDatasetList extends Component {
                 sortable: true,
                 hideable: false,
                 defaultHidden: false,
-                getCellValue: row => <a href={`/view?image=${row['dlfileid']}`} target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</a>
+                getCellValue: row => <a href={`/spatial-viewer/view?image=${row['dlfileid']}`} target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</a>
             },
             {
                 name: 'redcapid',

--- a/src/components/SpatialViewer/ImageDatasetList.js
+++ b/src/components/SpatialViewer/ImageDatasetList.js
@@ -107,7 +107,7 @@ class ImageDatasetList extends Component {
                 sortable: true,
                 hideable: false,
                 defaultHidden: false,
-                getCellValue: row => <a href='#' target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</a>
+                getCellValue: row => <a href={`/view?image=${row['dlfileid']}`} target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</a>
             },
             {
                 name: 'redcapid',

--- a/src/components/SpatialViewer/ImageDatasetList.js
+++ b/src/components/SpatialViewer/ImageDatasetList.js
@@ -107,7 +107,7 @@ class ImageDatasetList extends Component {
                 sortable: true,
                 hideable: false,
                 defaultHidden: false,
-                getCellValue: row => <a href={`/view?image=${row['dlfileid']}`} target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</a>
+                getCellValue: row => <a href={`spatial-viewer/view?image=${row['dlfileid']}`} target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</a>
             },
             {
                 name: 'redcapid',

--- a/src/components/SpatialViewer/ImageDatasetList.js
+++ b/src/components/SpatialViewer/ImageDatasetList.js
@@ -107,7 +107,7 @@ class ImageDatasetList extends Component {
                 sortable: true,
                 hideable: false,
                 defaultHidden: false,
-                getCellValue: row => <a href={`spatial-viewer/view?image=${row['dlfileid']}`} target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</a>
+                getCellValue: row => <a href={`/view?image=${row['dlfileid']}`} target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</a>
             },
             {
                 name: 'redcapid',

--- a/src/components/SpatialViewer/ImageDatasetListContainer.js
+++ b/src/components/SpatialViewer/ImageDatasetListContainer.js
@@ -27,7 +27,6 @@ const mapDispatchToProps = (dispatch, props) =>
                      window.open(selectedImageDataset['externallink'], '_blank')
                  } else {
                      dispatch(setSelectedImageDataset(selectedImageDataset));
-                    //  dispatch((dispatch) => props.history.push("/view?image=" + selectedImageDataset['dlfileid']));
                  }
              })
          },

--- a/src/components/SpatialViewer/ImageDatasetListContainer.js
+++ b/src/components/SpatialViewer/ImageDatasetListContainer.js
@@ -27,7 +27,7 @@ const mapDispatchToProps = (dispatch, props) =>
                      window.open(selectedImageDataset['externallink'], '_blank')
                  } else {
                      dispatch(setSelectedImageDataset(selectedImageDataset));
-                     dispatch((dispatch) => props.history.push("/view?image=" + selectedImageDataset['dlfileid']));
+                    //  dispatch((dispatch) => props.history.push("/view?image=" + selectedImageDataset['dlfileid']));
                  }
              })
          },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved spatial image dataset selection navigation to streamline access to the viewer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KPMP/hubble-web/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->