### PR TITLE
KPMP 6704 add icon to metaspace links

### DIFF
--- a/src/components/SpatialViewer/ImageDatasetList.js
+++ b/src/components/SpatialViewer/ImageDatasetList.js
@@ -112,7 +112,7 @@ class ImageDatasetList extends Component {
                         return <a href={`/spatial-viewer/view?image=${row['dlfileid']}`} target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</a>
 
                     }else {
-                        return <button onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]} <FontAwesomeIcon icon={faArrowUpRightFromSquare} /></button>
+                        return <button onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="Open in Metaspace" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]} <FontAwesomeIcon icon={faArrowUpRightFromSquare} /></button>
                     }
                 }
             },

--- a/src/components/SpatialViewer/ImageDatasetList.js
+++ b/src/components/SpatialViewer/ImageDatasetList.js
@@ -109,10 +109,10 @@ class ImageDatasetList extends Component {
                 defaultHidden: false,
                 getCellValue: row => {
                     if(row['configtype'] !== 'external_link') {
-                        return <a href={`/spatial-viewer/view?image=${row['dlfileid']}`} target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}<FontAwesomeIcon icon={faArrowUpRightFromSquare} /></a>
+                        return <a href={`/spatial-viewer/view?image=${row['dlfileid']}`} target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</a>
 
                     }else {
-                        return <button onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</button>
+                        return <button onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}<FontAwesomeIcon icon={faArrowUpRightFromSquare} /></button>
                     }
                 }
             },

--- a/src/components/SpatialViewer/ImageDatasetList.js
+++ b/src/components/SpatialViewer/ImageDatasetList.js
@@ -4,7 +4,7 @@ import { HTML5Backend } from 'react-dnd-html5-backend'
 import {Col, Container, Row, Spinner, UncontrolledTooltip} from "reactstrap";
 import { resultConverter } from "../../helpers/dataHelper";
 import { getImageTypeTooltipCopy } from "./viewConfigHelper";
-import { faXmark, faAnglesRight, faAnglesLeft, faTrashCan } from "@fortawesome/free-solid-svg-icons";
+import { faXmark, faAnglesRight, faAnglesLeft, faTrashCan, faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Tooltip } from "antd";
 import {
@@ -109,7 +109,7 @@ class ImageDatasetList extends Component {
                 defaultHidden: false,
                 getCellValue: row => {
                     if(row['configtype'] !== 'external_link') {
-                        return <a href={`/spatial-viewer/view?image=${row['dlfileid']}`} target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</a>
+                        return <a href={`/spatial-viewer/view?image=${row['dlfileid']}`} target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}<FontAwesomeIcon icon={faArrowUpRightFromSquare} /></a>
 
                     }else {
                         return <button onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</button>

--- a/src/components/SpatialViewer/ImageDatasetList.js
+++ b/src/components/SpatialViewer/ImageDatasetList.js
@@ -112,7 +112,7 @@ class ImageDatasetList extends Component {
                         return <a href={`/spatial-viewer/view?image=${row['dlfileid']}`} target='_self' onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}</a>
 
                     }else {
-                        return <button onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]}<FontAwesomeIcon icon={faArrowUpRightFromSquare} /></button>
+                        return <button onClick={() => setSelectedImageDataset(row)} type='button' data-toggle="tooltip" data-placement="top" title="View dataset" className='table-column btn btn-link text-start p-0 text-decoration-none'>{row["spectracksampleid"]} <FontAwesomeIcon icon={faArrowUpRightFromSquare} /></button>
                     }
                 }
             },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the dataset view button with a new label and external link icon. The button now displays "Open in Metaspace" instead of "View dataset" and includes a visual indicator to help users understand that the action navigates to an external resource.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KPMP/hubble-web/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->